### PR TITLE
fix regex for windows folders.

### DIFF
--- a/lib/color-tabs-byproject.coffee
+++ b/lib/color-tabs-byproject.coffee
@@ -165,7 +165,12 @@ resolveProjPath = (path) ->
   if !path
     return ''
   relPath = atom.project.relativizePath(path)[1]
-  projPath = path.replace(new RegExp("#{relPath}$"), "")
+  debug 'relPath:', relPath
+
+  regPath = relPath.replace(/\\/g, '\\\\')
+  debug 'regPath:', regPath
+  
+  projPath = path.replace(new RegExp("#{regPath}$"), "")
   return projPath
 
 processPath= (path,color,revert=false,save=false,warn=false) ->


### PR DESCRIPTION
**Related Issues**
<!-- Reference an related issue(s) here using #nnn, #123 -->
* #8 

**Description of Proposed Changes**
<!-- Describe your proposed changes here: -->
* Escape backslashes in relPath for regex to support windows folders

**Reviewers**
* @gbevan
