### PR TITLE
Rules based on project name, not only on project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@ applied and modified to color tabs by project root folder and optionally
 by subfolder levels within the project tree.
 
 ## Edit per project rules
-Use menu `Packages -> Color Tabs by Project -> Edit Rules` to open the rules editor:
+There are two ways of setting custom rules for your projects.
+Use menu `Packages -> Color Tabs by Project -> Edit Rules` to open the rules editor, then:
++ if `Custom rules based on` is set to `project path`
 ```cson
 projects:
   "/your-project-path/":
     folderDepth: 1
     color: "#980909"
 ```
++ if  `Custom rules based on` is set to `project name`
+```cson
+projects:
+  "your-project-name":
+    folderDepth: 1
+    color: "#980909"
+```
 The hashed color is saved in the above project entry and can be overridden by
-Editting the above (e.g. using package color-picker).
+Editing the above (e.g. using package color-picker).
 
 ## Developing
 

--- a/lib/color-tabs-byproject.coffee
+++ b/lib/color-tabs-byproject.coffee
@@ -149,17 +149,21 @@ getDeterministicColor= (path) ->
   return hashbow(projPath)
 
 getColorForPath = (path) ->
-  # debug 'getColorForPath path:', path
   switch atom.config.get "color-tabs-byproject.colorSelection"
     when 'deterministic'
       projPath = resolveProjPath path
       projName = basename projPath
-      # debug 'getColorForPath: projPath:', projPath
-      if rules && rules.projects && rules.projects[projPath] && rules.projects[projPath].color
-        # debug 'getColorForPath: rules.projects[projPath].color:', rules.projects[projPath].color
-        return rules.projects[projPath].color
-      else
-        return getDeterministicColor(projPath)
+      switch atom.config.get "color-tabs-byproject.referTo"
+        when 'project name'
+          if rules && rules.projects && rules.projects[projName] && rules.projects[projName].color
+            return rules.projects[projName].color
+          else
+            return getDeterministicColor(projName)
+        when 'project path'
+          if rules && rules.projects && rules.projects[projPath] && rules.projects[projPath].color
+           return rules.projects[projPath].color
+          else
+            return getDeterministicColor(projPath)
 
 resolveProjPath = (path) ->
   if !path

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,6 +34,12 @@ module.exports = new class Main
       type: "string"
       default: "deterministic"
       enum: ["deterministic"]
+    referTo:
+      title: "Custom rules based on"
+      description: "Set rules based on project name, or project full path"
+      type: "string"
+      default: "project name"
+      enum: ["project name", "project path"]
     folderDepth:
       title: "Folder Depth"
       description: "Folder Depth to have own color in project (see Edit Rules for per-project rules)"


### PR DESCRIPTION
**Description of Proposed Changes**
<!-- Describe your proposed changes here: -->
My pull request enable users to edit rules using simply project name, not only project path. So far, these options are mutually exclusive, but they might easily coexist.
Files changed:
+ lib/color-tabs-byproject.coffee
+ lib/main.coffee
+ README.md

**Reviewers**
* @gbevan
